### PR TITLE
Fix for Group object type value

### DIFF
--- a/TinCan/Agent.cs
+++ b/TinCan/Agent.cs
@@ -23,7 +23,7 @@ namespace TinCan
     public class Agent : JsonModel, IStatementTarget
     {
         public static readonly string OBJECT_TYPE = "Agent";
-        public string ObjectType => OBJECT_TYPE;
+        public virtual string ObjectType => OBJECT_TYPE;
 
         public string Name { get; set; }
         public string Mbox { get; set; }

--- a/TinCan/Group.cs
+++ b/TinCan/Group.cs
@@ -23,6 +23,9 @@ namespace TinCan
 {
     public class Group : Agent
     {
+        public static readonly new string OBJECT_TYPE = "Group";
+        public override string ObjectType => OBJECT_TYPE;
+
         public List<Agent> Member { get; set; }
 
         public Group() : base() { }


### PR DESCRIPTION
Object Type for Group is also publishing as Agent which is wrong as per xAPI specifications.
If we use group in xAPI statement and publish to Veracity (LRS), it fails because of wrong object type value.